### PR TITLE
Switch from `must_*` to `try_*` naming convetion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.3.0] · 2022-12-??
+[0.3.0]: /../../tree/v0.3.0
+
+[Diff](/../../compare/v0.2.0...v0.3.0)
+
+### BC Breaks
+
+- Switched functions naming convention from `must_*` for panicking to `try_*` for fallible. ([#1])
+
+[#1]: /../../pull/1
+
+
+
+
 ## [0.2.0] · 2022-12-08
 [0.2.0]: /../../tree/v0.2.0
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To satisfy the [`metrics::Recorder`]'s requirement of allowing changing metrics 
 
 ```rust
 // By default `prometheus::default_registry()` is used.
-let recorder = metrics_prometheus::must_install();
+let recorder = metrics_prometheus::install();
 
 // Either use `metrics` crate interfaces.
 metrics::increment_counter!("count", "whose" => "mine", "kind" => "owned");
@@ -55,7 +55,7 @@ metrics::increment_counter!("count", "whose" => "mine", "kind" => "ref");
 metrics::increment_counter!("count", "kind" => "owned", "whose" => "dummy");
 
 // Or construct and provide `prometheus` metrics directly.
-recorder.register_metric(prometheus::Gauge::new("value", "help")?)?;
+recorder.register_metric(prometheus::Gauge::new("value", "help")?);
 
 let report = prometheus::TextEncoder::new()
     .encode_to_string(&prometheus::default_registry().gather())?;
@@ -132,7 +132,7 @@ Since [`prometheus`] crate validates the metrics format very strictly, not every
 
 - Metric names cannot be namespaced with dots (and should follow [Prometheus] format).
   ```rust,should_panic
-  metrics_prometheus::must_install();
+  metrics_prometheus::install();
 
   // panics: 'queries.count' is not a valid metric name
   metrics::increment_counter!("queries.count");
@@ -140,21 +140,21 @@ Since [`prometheus`] crate validates the metrics format very strictly, not every
 
 - The same metric should use always the same set of labels:
   ```rust,should_panic
-  metrics_prometheus::must_install();
+  metrics_prometheus::install();
 
   metrics::increment_counter!("count");
   // panics: Inconsistent label cardinality, expect 0 label values, but got 1
   metrics::increment_counter!("count", "whose" => "mine");
   ```
   ```rust,should_panic
-  metrics_prometheus::must_install();
+  metrics_prometheus::install();
 
   metrics::increment_counter!("count", "kind" => "owned");
   // panics: label name kind missing in label map
   metrics::increment_counter!("count", "whose" => "mine");
   ```
   ```rust,should_panic
-  metrics_prometheus::must_install();
+  metrics_prometheus::install();
 
   metrics::increment_counter!("count", "kind" => "owned");
   // panics: Inconsistent label cardinality, expect 1 label values, but got 2
@@ -163,7 +163,7 @@ Since [`prometheus`] crate validates the metrics format very strictly, not every
 
 - The same name cannot be used for different types of metrics:
   ```rust,should_panic
-  metrics_prometheus::must_install();
+  metrics_prometheus::install();
 
   metrics::increment_counter!("count");
   // panics: Duplicate metrics collector registration attempted
@@ -172,7 +172,7 @@ Since [`prometheus`] crate validates the metrics format very strictly, not every
 
 - Any metric registered in a [`prometheus::Registry`] directly, without using [`metrics`] or this crate interfaces, is not usable via [`metrics`] facade and will cause a [`prometheus::Error`].
   ```rust,should_panic
-  metrics_prometheus::must_install();
+  metrics_prometheus::install();
   
   prometheus::default_registry()
       .register(Box::new(prometheus::Gauge::new("value", "help")?))?;
@@ -196,7 +196,7 @@ use metrics_prometheus::failure::strategy;
 
 metrics_prometheus::Recorder::builder()
     .with_failure_strategy(strategy::NoOp)
-    .must_build_and_install();
+    .build_and_install();
 
 // `prometheus::Error` is ignored inside.
 metrics::increment_counter!("invalid.name");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,14 +151,14 @@ use thiserror as _;
 #[doc(inline)]
 pub use self::{metric::Metric, recorder::Recorder};
 
-/// Installs a default [`Recorder`] (backed by the
+/// Tries to install a default [`Recorder`] (backed by the
 /// [`prometheus::default_registry()`]) as [`metrics::recorder()`].
 ///
 /// # Errors
 ///
 /// If the [`Recorder`] fails to be installed as [`metrics::recorder()`].
-pub fn install() -> Result<Recorder, metrics::SetRecorderError> {
-    Recorder::builder().build_and_install()
+pub fn try_install() -> Result<Recorder, metrics::SetRecorderError> {
+    Recorder::builder().try_build_and_install()
 }
 
 /// Installs a default [`Recorder`] (backed by the
@@ -170,8 +170,8 @@ pub fn install() -> Result<Recorder, metrics::SetRecorderError> {
 // We do intentionally omit `#[must_use]` here, as we don't want to force
 // library users using the returned `Recorder` directly.
 #[allow(clippy::must_use_candidate)]
-pub fn must_install() -> Recorder {
-    Recorder::builder().must_build_and_install()
+pub fn install() -> Recorder {
+    Recorder::builder().build_and_install()
 }
 
 /// Ad hoc polymorphism for accepting either a reference or an owned function


### PR DESCRIPTION
## Synopsis

At the moment, we use `must_*` naming conventions for panicking functions.




## Solution

Seems to be more idiomatic to use `try_*` naming convention for fallible functions instead.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
