### PR TITLE
Strip redundant `Arc` allocation on hot pahs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ arc-swap = "1.5"
 metrics = { version = "0.20", default-features = false }
 metrics-util = { version = "0.14", features = ["registry"], default-features = false }
 once_cell = "1.16"
-prometheus = { version = "0.13", default-features = false }
+#prometheus = { version = "0.13", default-features = false }
+prometheus = { git = "https://github.com/tyranron/rust-prometheus", branch = "raw-value-access", default-features = false }
 sealed = "0.4"
 smallvec = "1.10"
 


### PR DESCRIPTION
Requires tikv/rust-prometheus#472


## Synopsis

There are some [redundant `Arc` allocations on hot paths](https://github.com/instrumentisto/metrics-prometheus-rs/blob/v0.3.0/src/recorder/frozen.rs#L216-L217) due to upstream APIs.




## Solution

Eliminate these allocations by re-using the inner `Arc` of metrics from `prometheus` crate.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
