### PR TITLE
Add `recorder::Builder::build()`, `recorder::Builder::build_freezable()` and `recorder::Builder::build_frozen()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.3.1] · 2023-01-??
+[0.3.1]: /../../tree/v0.3.1
+
+[Diff](/../../compare/v0.3.0...v0.3.1)
+
+### Added
+
+- `recorder::Builder::build()`, `recorder::Builder::build_freezable()` and `recorder::Builder::build_frozen()` methods. ([#4])
+
+[#3]: /../../pull/4
+
+
+
+
 ## [0.3.0] · 2022-12-11
 [0.3.0]: /../../tree/v0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Added
 
-- `recorder::Builder::build()`, `recorder::Builder::build_freezable()` and `recorder::Builder::build_frozen()` methods. ([#4])
+- `build()`, `build_freezable()` and `build_frozen()` methods to `recorder::Builder`, allowing to build the resulting `metrics::Recorder` without installing it as `metrics::recorder()`. ([#4])
 
 [#3]: /../../pull/4
 

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -729,7 +729,7 @@ impl<S, L> Builder<S, L> {
     /// - either install the built [`Recorder`] as [`metrics::recorder()`]
     ///   manually;
     /// - or to compose the built [`Recorder`] with some other
-    ///   [`metric::Recorder`]s (like being able to write into multiple
+    ///   [`metrics::Recorder`]s (like being able to write into multiple
     ///   [`prometheus::Registry`]s via [`metrics::layer::Fanout`], for
     ///   example).
     ///
@@ -762,7 +762,7 @@ impl<S, L> Builder<S, L> {
     /// - either install the built [`FreezableRecorder`] as
     ///   [`metrics::recorder()`] manually;
     /// - or to compose the built [`FreezableRecorder`] with some other
-    ///   [`metric::Recorder`]s (like being able to write into multiple
+    ///   [`metrics::Recorder`]s (like being able to write into multiple
     ///   [`prometheus::Registry`]s via [`metrics::layer::Fanout`], for
     ///   example).
     ///
@@ -797,7 +797,7 @@ impl<S, L> Builder<S, L> {
     /// - either install the built [`FrozenRecorder`] as [`metrics::recorder()`]
     ///   manually;
     /// - or to compose the built [`FrozenRecorder`] with some other
-    ///   [`metric::Recorder`]s (like being able to write into multiple
+    ///   [`metrics::Recorder`]s (like being able to write into multiple
     ///   [`prometheus::Registry`]s via [`metrics::layer::Fanout`], for
     ///   example).
     ///

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -720,6 +720,52 @@ impl<S, L> Builder<S, L> {
         })
     }
 
+    /// Builds a [`Recorder`] out of this [`Builder`].
+    pub fn build(self) -> <L as Layer<Recorder<S>>>::Output
+    where
+        S: failure::Strategy,
+        L: Layer<Recorder<S>>,
+    {
+        let Self { storage, failure_strategy, layers } = self;
+        let rec = Recorder {
+            metrics: Arc::new(metrics_util::registry::Registry::new(
+                storage.clone(),
+            )),
+            storage,
+            failure_strategy,
+        };
+        layers.layer(rec)
+    }
+
+    /// Builds a [`FreezableRecorder`] out of this [`Builder`].
+    pub fn build_freezable(self) -> <L as Layer<freezable::Recorder<S>>>::Output
+    where
+        S: failure::Strategy,
+        L: Layer<freezable::Recorder<S>>,
+    {
+        let Self { storage, failure_strategy, layers } = self;
+        let rec = freezable::Recorder::wrap(Recorder {
+            metrics: Arc::new(metrics_util::registry::Registry::new(
+                storage.clone(),
+            )),
+            storage,
+            failure_strategy,
+        });
+        layers.layer(rec)
+    }
+
+    /// Builds a [`FrozenRecorder`] out of this [`Builder`].
+    pub fn build_frozen(self) -> <L as Layer<frozen::Recorder<S>>>::Output
+    where
+        S: failure::Strategy,
+        L: Layer<frozen::Recorder<S>>,
+    {
+        let Self { storage, failure_strategy, layers } = self;
+        let rec =
+            frozen::Recorder { storage: (&storage).into(), failure_strategy };
+        layers.layer(rec)
+    }
+
     /// Builds a [`Recorder`] out of this [`Builder`] and tries to install it as
     /// [`metrics::recorder()`].
     ///

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -737,6 +737,7 @@ impl<S, L> Builder<S, L> {
     ///
     /// [`build_and_install()`]: Builder::build_and_install
     /// [`metrics::layer::Fanout`]: metrics_util::layers::Fanout
+    /// [`metrics::Layer`]: Layer
     pub fn build(self) -> <L as Layer<Recorder<S>>>::Output
     where
         S: failure::Strategy,
@@ -771,6 +772,7 @@ impl<S, L> Builder<S, L> {
     ///
     /// [`build_freezable_and_install()`]: Builder::build_freezable_and_install
     /// [`metrics::layer::Fanout`]: metrics_util::layers::Fanout
+    /// [`metrics::Layer`]: Layer
     /// [`FreezableRecorder`]: Freezable
     pub fn build_freezable(self) -> <L as Layer<freezable::Recorder<S>>>::Output
     where
@@ -806,6 +808,7 @@ impl<S, L> Builder<S, L> {
     ///
     /// [`build_frozen_and_install()`]: Builder::build_frozen_and_install
     /// [`metrics::layer::Fanout`]: metrics_util::layers::Fanout
+    /// [`metrics::Layer`]: Layer
     /// [`FrozenRecorder`]: Frozen
     pub fn build_frozen(self) -> <L as Layer<frozen::Recorder<S>>>::Output
     where

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -720,7 +720,23 @@ impl<S, L> Builder<S, L> {
         })
     }
 
-    /// Builds a [`Recorder`] out of this [`Builder`].
+    /// Builds a [`Recorder`] out of this [`Builder`] and returns it being
+    /// wrapped into all the provided [`metrics::Layer`]s.
+    ///
+    /// # Usage
+    ///
+    /// Use this method if you want to:
+    /// - either install the built [`Recorder`] as [`metrics::recorder()`]
+    ///   manually;
+    /// - or to compose the built [`Recorder`] with some other
+    ///   [`metric::Recorder`]s (like being able to write into multiple
+    ///   [`prometheus::Registry`]s via [`metrics::layer::Fanout`], for
+    ///   example).
+    ///
+    /// Otherwise, consider using the [`build_and_install()`] method instead.
+    ///
+    /// [`build_and_install()`]: Builder::build_and_install
+    /// [`metrics::layer::Fanout`]: metrics_util::layers::Fanout
     pub fn build(self) -> <L as Layer<Recorder<S>>>::Output
     where
         S: failure::Strategy,
@@ -737,8 +753,24 @@ impl<S, L> Builder<S, L> {
         layers.layer(rec)
     }
 
-    /// Builds a [`FreezableRecorder`] out of this [`Builder`].
+    /// Builds a [`FreezableRecorder`] out of this [`Builder`] and returns it
+    /// being wrapped into all the provided [`metrics::Layer`]s.
     ///
+    /// # Usage
+    ///
+    /// Use this method if you want to:
+    /// - either install the built [`FreezableRecorder`] as
+    ///   [`metrics::recorder()`] manually;
+    /// - or to compose the built [`FreezableRecorder`] with some other
+    ///   [`metric::Recorder`]s (like being able to write into multiple
+    ///   [`prometheus::Registry`]s via [`metrics::layer::Fanout`], for
+    ///   example).
+    ///
+    /// Otherwise, consider using the [`build_freezable_and_install()`] method
+    /// instead.
+    ///
+    /// [`build_freezable_and_install()`]: Builder::build_freezable_and_install
+    /// [`metrics::layer::Fanout`]: metrics_util::layers::Fanout
     /// [`FreezableRecorder`]: Freezable
     pub fn build_freezable(self) -> <L as Layer<freezable::Recorder<S>>>::Output
     where
@@ -756,8 +788,24 @@ impl<S, L> Builder<S, L> {
         layers.layer(rec)
     }
 
-    /// Builds a [`FrozenRecorder`] out of this [`Builder`].
+    /// Builds a [`FrozenRecorder`] out of this [`Builder`] and returns it being
+    /// wrapped into all the provided [`metrics::Layer`]s.
     ///
+    /// # Usage
+    ///
+    /// Use this method if you want to:
+    /// - either install the built [`FrozenRecorder`] as [`metrics::recorder()`]
+    ///   manually;
+    /// - or to compose the built [`FrozenRecorder`] with some other
+    ///   [`metric::Recorder`]s (like being able to write into multiple
+    ///   [`prometheus::Registry`]s via [`metrics::layer::Fanout`], for
+    ///   example).
+    ///
+    /// Otherwise, consider using the [`build_frozen_and_install()`] method
+    /// instead.
+    ///
+    /// [`build_frozen_and_install()`]: Builder::build_frozen_and_install
+    /// [`metrics::layer::Fanout`]: metrics_util::layers::Fanout
     /// [`FrozenRecorder`]: Frozen
     pub fn build_frozen(self) -> <L as Layer<frozen::Recorder<S>>>::Output
     where

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -738,6 +738,8 @@ impl<S, L> Builder<S, L> {
     }
 
     /// Builds a [`FreezableRecorder`] out of this [`Builder`].
+    ///
+    /// [`FreezableRecorder`]: Freezable
     pub fn build_freezable(self) -> <L as Layer<freezable::Recorder<S>>>::Output
     where
         S: failure::Strategy,
@@ -755,6 +757,8 @@ impl<S, L> Builder<S, L> {
     }
 
     /// Builds a [`FrozenRecorder`] out of this [`Builder`].
+    ///
+    /// [`FrozenRecorder`]: Frozen
     pub fn build_frozen(self) -> <L as Layer<frozen::Recorder<S>>>::Output
     where
         S: failure::Strategy,


### PR DESCRIPTION
## Synopsis

To be able to compose `Recorder`s, we need `build_*()` methods in addition to `build_*_and_install()`.




## Solution

Add `build_*()` methods in addition to `build_*_and_install()`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
