### PR TITLE
Upgrade `metrics` to 0.23 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.65.0"]
+        msrv: ["1.70.0"]
         os: ["ubuntu", "macOS", "windows"]
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.70.0"]
+        msrv: ["1.72.0"]
         os: ["ubuntu", "macOS", "windows"]
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.7.0] · 2024-??-?? (unreleased)
+[0.7.0]: /../../tree/v0.7.0
+
+[Diff](/../../compare/v0.6.0...v0.7.0)
+
+### BC Breaks
+
+- Upgraded to 0.23 version of `metrics` crate. ([#11], [#10])
+- Upgraded to 0.13 version of `metrics-util` crate. ([#11], [#10])
+- Bumped up [MSRV] to 1.72 because of newer dependencies versions. ([#11], [#10])
+
+[#10]: /../../issues/10
+[#11]: /../../pull/11
+
+
+
+
 ## [0.6.0] · 2023-12-25
 [0.6.0]: /../../tree/v0.6.0
 
@@ -119,4 +136,5 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+[MSRV]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
 [Semantic Versioning 2.0.0]: https://semver.org

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ include = ["/src/", "/CHANGELOG.md", "/LICENSE-APACHE", "/LICENSE-MIT", "/README
 
 [dependencies]
 arc-swap = "1.5"
-metrics = { version = "0.22", default-features = false }
-metrics-util = { version = "0.16", features = ["registry"], default-features = false }
+metrics = { version = "0.23", default-features = false }
+metrics-util = { version = "0.17", features = ["registry"], default-features = false }
 once_cell = "1.16"
 prometheus = { version = "0.13", default-features = false }
 sealed = "0.5"
@@ -28,4 +28,4 @@ smallvec = "1.10"
 thiserror = "1.0.2"
 
 [dev-dependencies]
-metrics-util = { version = "0.16", features = ["layer-filter"], default-features = false }
+metrics-util = { version = "0.17", features = ["layer-filter"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "metrics-prometheus"
 version = "0.6.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.72"
 description = "`prometheus` backend for `metrics` crate."
 authors = ["Instrumentisto Team <developer@instrumentisto.com>"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "metrics-prometheus"
 version = "0.6.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 description = "`prometheus` backend for `metrics` crate."
 authors = ["Instrumentisto Team <developer@instrumentisto.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 =================================
 
 [![crates.io](https://img.shields.io/crates/v/metrics-prometheus.svg "crates.io")](https://crates.io/crates/metrics-prometheus)
-[![Rust 1.70+](https://img.shields.io/badge/rustc-1.70+-lightgray.svg "Rust 1.70+")](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
+[![Rust 1.72+](https://img.shields.io/badge/rustc-1.72+-lightgray.svg "Rust 1.72+")](https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html)
 [![Unsafe Forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden")](https://github.com/rust-secure-code/safety-dance)  
 [![CI](https://github.com/instrumentisto/metrics-prometheus-rs/workflows/CI/badge.svg?branch=main "CI")](https://github.com/instrumentisto/metrics-prometheus-rs/actions?query=workflow%3ACI+branch%3Amain)
 [![Rust docs](https://docs.rs/metrics-prometheus/badge.svg "Rust docs")](https://docs.rs/metrics-prometheus)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 =================================
 
 [![crates.io](https://img.shields.io/crates/v/metrics-prometheus.svg "crates.io")](https://crates.io/crates/metrics-prometheus)
-[![Rust 1.65+](https://img.shields.io/badge/rustc-1.65+-lightgray.svg "Rust 1.65+")](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
+[![Rust 1.70+](https://img.shields.io/badge/rustc-1.70+-lightgray.svg "Rust 1.70+")](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
 [![Unsafe Forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden")](https://github.com/rust-secure-code/safety-dance)  
 [![CI](https://github.com/instrumentisto/metrics-prometheus-rs/workflows/CI/badge.svg?branch=main "CI")](https://github.com/instrumentisto/metrics-prometheus-rs/actions?query=workflow%3ACI+branch%3Amain)
 [![Rust docs](https://docs.rs/metrics-prometheus/badge.svg "Rust docs")](https://docs.rs/metrics-prometheus)


### PR DESCRIPTION
Resolves #10




## Synopsis

0.23 version of `metrics` crate is out.




## Solution

Upgrade `metrics` crate and the related crates.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
